### PR TITLE
Upgrade to Spring Data Hadoop 2.0.3.RELEASE

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -50,7 +50,7 @@
 
 		<spring-amqp.version>1.3.6.RELEASE</spring-amqp.version>
 		<spring-cloud.version>1.0.0.RELEASE</spring-cloud.version>
-		<spring-data-hadoop.version>2.0.2.RELEASE</spring-data-hadoop.version>
+		<spring-data-hadoop.version>2.0.3.RELEASE</spring-data-hadoop.version>
 		<spring-integration.version>4.0.4.RELEASE</spring-integration.version>
 		<spring-ldap.version>2.0.2.RELEASE</spring-ldap.version>
 		<spring-plugin.version>1.1.0.RELEASE</spring-plugin.version>

--- a/platform-definition.yaml
+++ b/platform-definition.yaml
@@ -271,7 +271,7 @@ platform_definition:
         - spring-websocket
     - name: Spring Hadoop
       groupId: org.springframework.data
-      version: 2.0.2.RELEASE
+      version: 2.0.3.RELEASE
       build:
         repository: https://github.com/spring-projects/spring-hadoop
         additional_tasks: build -x test


### PR DESCRIPTION
- The new 2.0.3.RELEASE has been updated to use dependency versions based on IO Platform 1.0.3
