### PR TITLE
Rename spring-boot-configuration-metadata

### DIFF
--- a/platform-definition.yaml
+++ b/platform-definition.yaml
@@ -132,7 +132,7 @@ platform_definition:
         - spring-boot-actuator
         - spring-boot-autoconfigure
         - spring-boot-cli
-        - spring-boot-configuration-metadata
+        - spring-boot-configuration-processor
         - spring-boot-dependencies
         - spring-boot-dependency-tools
         - spring-boot-loader
@@ -487,7 +487,7 @@ platform_definition:
       - 'org.grails' # Grails is a special case. As recommended by Graeme, the Platform only contains grails-dependencies
       - 'org.springframework.boot:spring-boot-cli' # The CLI doesn't expose its dependencies to applications
       - 'org.springframework.boot:spring-boot-maven-plugin' # The plugin doesn't expose it dependencies to applications
-      - 'org.springframework.boot:spring-boot-configuration-metadata' # Used by the Boot build to generate metadata about @ConfigurationProperties
+      - 'org.springframework.boot:spring-boot-configuration-processor' # Used by the Boot build to generate metadata about @ConfigurationProperties
   unused_dependencies:
     ignored:
       # For user convenience, Boot provides extra dependency management for modules that both it


### PR DESCRIPTION
The module that holds the annotation processor responsible to generate
meta-data about configuration properties is actually named
spring-boot-configuration-processor
