### PR TITLE
Update dependency-management-plugin in build.gradle

### DIFF
--- a/_includes/build.gradle
+++ b/_includes/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'io.spring.gradle:dependency-management-plugin:0.3.0.RELEASE'
+        classpath 'io.spring.gradle:dependency-management-plugin:0.5.1.RELEASE'
     }
 }
 


### PR DESCRIPTION
Update dependency-management-plugin to 0.5.1.RELEASE in the excample
build.gradle file.