### PR TITLE
Upgrade Kryo to 3.0.3

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -132,7 +132,7 @@
 		<jxl.version>2.6.12</jxl.version>
 		<kafka.version>0.8.2.1</kafka.version>
 		<kite.version>0.13.0</kite.version>
-		<kryo.version>2.22</kryo.version>
+		<kryo.version>3.0.3</kryo.version>
 		<ldapbp.version>1.0</ldapbp.version>
 		<ldapsdk.version>4.1</ldapsdk.version>
 		<lettuce.version>2.3.3</lettuce.version>
@@ -333,8 +333,8 @@
 				<version>${cassandra-driver.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>com.esotericsoftware.kryo</groupId>
-				<artifactId>kryo</artifactId>
+				<groupId>com.esotericsoftware</groupId>
+				<artifactId>kryo-shaded</artifactId>
 				<version>${kryo.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
The Spring XD has moved its Kryo Codecs to SI Core,
hence we have there a new Kryo dependency.

According to the README on the Kryo site (https://github.com/EsotericSoftware/kryo)
it is better to use `kryo-shaded` artifact to avoid conflicts with our ASM jar.

So, this fix change `kryo` artifact to `kryo-shaded` and raise its version to the `3.0.3`