### PR TITLE
Update money-api to 1.0

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -112,7 +112,7 @@
 		<javax-jdo.version>3.0.1</javax-jdo.version>
 		<javax-jsp.version>2.2.1</javax-jsp.version>
 		<javax-jstl.version>1.2.1</javax-jstl.version>
-		<javax-money.version>1.0-RC3</javax-money.version>
+		<javax-money.version>1.0</javax-money.version>
 		<javax-portlet.version>2.0</javax-portlet.version>
 		<javax-saaj.version>1.3.5</javax-saaj.version>
 		<javax-validation.version>1.1.0.Final</javax-validation.version>


### PR DESCRIPTION
Update money-api version from 1.0-RC3 to 1.0.
Version 1.0 GA has been released at May, 2015.