### PR TITLE
GH-341: Downgrade to curator-2.10.0. Remove ZK

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -73,7 +73,7 @@
 		<commons-lang3.version>3.4</commons-lang3.version>
 		<commons-logging.version>1.2</commons-logging.version>
 		<commons-net.version>3.4</commons-net.version>
-		<curator.version>3.1.0</curator.version>
+		<curator.version>2.10.0</curator.version>
 		<eclipselink.version>2.5.2</eclipselink.version>
 		<eclipselink-javax-persistence.version>2.1.1</eclipselink-javax-persistence.version>
 		<evo-inflector.version>1.1</evo-inflector.version>
@@ -181,7 +181,6 @@
 		<xstream.version>1.4.8</xstream.version>
 		<xws-security.version>3.0</xws-security.version>
 		<yammer-metrics.version>2.2.0</yammer-metrics.version>
-		<zookeeper.version>3.4.8</zookeeper.version>
 	</properties>
 
 	<dependencyManagement>
@@ -871,11 +870,6 @@
 				<groupId>org.apache.ws.xmlschema</groupId>
 				<artifactId>xmlschema-core</artifactId>
 				<version>${xmlschema.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.zookeeper</groupId>
-				<artifactId>zookeeper</artifactId>
-				<version>${zookeeper.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.atteo</groupId>


### PR DESCRIPTION
Fixes GH-341 (https://github.com/spring-io/platform/issues/341)

The previous upgrade to `curator-3.1.0` was wrong, because it isn't compatible with the latest stable ZK (3.4.8)
And pulls `alpha` (3.5.1) version as transitive dependency.
That makes our test incompatible when platform re-map transitive version to our stable.

* Downgrade to `curator-2.10.0` according their note (http://curator.apache.org/):

> The are currently two released versions of Curator, 2.x.x and 3.x.x:

>    Curator 2.x.x - compatible with both ZooKeeper 3.4.x and ZooKeeper 3.5.x
>    Curator 3.x.x - compatible only with ZooKeeper 3.5.x and includes support for new features such as dynamic reconfiguration, etc.

To avoid the `alpha` version in the IO.

* Remove an explicit `ZK` dependency in favor of the transitive from the `curator`.