### PR TITLE
Upgrade commons-lang3 to 3.5

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -69,7 +69,7 @@
 		<commons-io.version>2.5</commons-io.version>
 		<commons-httpclient.version>3.1</commons-httpclient.version>
 		<commons-lang.version>2.6</commons-lang.version>
-		<commons-lang3.version>3.4</commons-lang3.version>
+		<commons-lang3.version>3.5</commons-lang3.version>
 		<commons-logging.version>1.2</commons-logging.version>
 		<commons-net.version>3.5</commons-net.version>
 		<curator.version>2.11.1</curator.version>


### PR DESCRIPTION
> Apache Commons Lang 3.5 is binary compatible with the 3.4 release.

Reference: https://commons.apache.org/proper/commons-lang/release-notes/RELEASE-NOTES-3.5.txt

See #271