### PR TITLE
Add Spring Data Geode

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -58,6 +58,7 @@
 		<aalto-xml.version>1.0.0</aalto-xml.version>
 		<api-guardian.version>1.0.0</api-guardian.version>
 		<apacheds.version>1.5.5</apacheds.version>
+		<apache-geode.version>1.2.1</apache-geode.version>
 		<apache-shared-ldap.version>0.9.15</apache-shared-ldap.version>
 		<apache-shiro.version>1.4.0</apache-shiro.version>
 		<axiom.version>1.2.20</axiom.version>
@@ -665,6 +666,69 @@
 				<groupId>org.apache.directory.shared</groupId>
 				<artifactId>shared-ldap</artifactId>
 				<version>${apache-shared-ldap.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-common</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-core</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-cq</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-json</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-junit</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-lucene</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-old-client-support</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-pulse</artifactId>
+				<version>${apache-geode.version}</version>
+				<type>war</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-rebalancer</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-wan</artifactId>
+				<version>${apache-geode.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-web</artifactId>
+				<version>${apache-geode.version}</version>
+				<type>war</type>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.geode</groupId>
+				<artifactId>geode-web-api</artifactId>
+				<version>${apache-geode.version}</version>
+				<type>war</type>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.kafka</groupId>

--- a/platform-definition.yaml
+++ b/platform-definition.yaml
@@ -146,6 +146,11 @@ platform_definition:
       version: 2.0.2.RELEASE
       modules:
         - spring-data-gemfire
+    - name: Spring Data Geode
+      groupId: org.springframework.data
+      version: 2.0.2.RELEASE
+      modules:
+        - spring-data-geode
     - name: Spring Data JPA
       groupId: org.springframework.data
       version: 2.0.2.RELEASE
@@ -435,6 +440,8 @@ platform_definition:
       'org.springframework.data:spring-data-gemfire':
          - 'org.springframework.shell:spring-shell'
          - 'org.iq80.snappy:snappy'
+      'org.springframework.data:spring-data-geode':
+         - 'org.iq80.snappy:snappy'
       'org.springframework.data:spring-data-rest-webmvc':
          - 'com.fasterxml.jackson.datatype:jackson-datatype-hibernate4'
       'org.springframework.social:spring-social-web':
@@ -604,6 +611,14 @@ platform_definition:
       - 'org.apache.activemq:artemis-selector'
       - 'org.apache.activemq:artemis-server'
       - 'org.apache.activemq:artemis-service-extensions'
+      - 'org.apache.geode:geode-common'
+      - 'org.apache.geode:geode-json'
+      - 'org.apache.geode:geode-junit'
+      - 'org.apache.geode:geode-old-client-support'
+      - 'org.apache.geode:geode-pulse'
+      - 'org.apache.geode:geode-rebalancer'
+      - 'org.apache.geode:geode-web'
+      - 'org.apache.geode:geode-web-api'
       - 'org.apache.httpcomponents:httpcore'
       - 'org.apache.httpcomponents:httpcore-nio'
       - 'org.apache.johnzon:johnzon-jsonb'


### PR DESCRIPTION
Fixes gh-513

Please note: @trevormarshall and I are currently in the process of adding a [geode-snapshot](https://repo.spring.io/webapp/#/artifacts/browse/tree/General/geode-snapshot) cache to _Spring's_ Artifactory server.  This will make _Apache Geode_ artifacts (e.g. `geode-core`) accessible from [spring-snapshots](http://repo.spring.io/libs-snapshot) as well as make the following [repository declaration](https://github.com/jxblum/platform/blob/gh-513/platform-definition.yaml#L692-L693) in the _Spring IO Platform_, `platform-definition.yaml` file unnecessary.

However, due to a **JFrog** problem, when the `geode-snapshots` cache was setup, the new snapshot repo was unable to "cache" the _Apache Geode_ artifacts accordingly due to a connection problem in their Google infrastructure, which subsequently caused their Hazelcast nodes to crap out during replication (as described in JFrog's support emails).

Anyway, I only mention all this since the _Spring IO Platform_, `io.spring.platform.MavenDependenciesTests.allManagedDependenciesCanBeResolved(..)` test case recognizes that it should be able to resolve the _Apache Geode_ artifacts from http://repo.spring.io/libs-snapshot but currently can't due to this Artifactory issue caused by JFrog, and as such, is throwing the following error...

```
[ERROR] Failed to execute goal on project maven-test: Could not resolve dependencies for project test:maven-test:jar:1.0.0.BUILD-SNAPSHOT: Could not find artifact org.apache.geode:geode-core:jar:1.1.0-20170127.162511-66 in spring-snapshots (http://repo.spring.io/libs-snapshot) -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 203.444 sec <<< FAILURE!
allManagedDependenciesCanBeResolved(io.spring.platform.MavenDependenciesTests)  Time elapsed: 203.439 sec  <<< ERROR!
java.lang.IllegalStateException: Maven build execution failed
```

Before this `geode-snapshots` cache repo existed, I was able to successfully run the _Spring IO Platform_ build, and the build was able to successfully resolve the Apache Geode artifacts from... 
`https://repository.apache.org/content/repositories/snapshots`.  However, ideally, we won't have to rely on this Apache snapshots repo and this should be resolved soon.
