### PR TITLE
Upgrade Lettuce version to 5.0.0.Beta1

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -125,7 +125,7 @@
 		<kryo.version>3.0.3</kryo.version>
 		<ldapbp.version>1.0</ldapbp.version>
 		<ldapsdk.version>4.1</ldapsdk.version>
-		<lettuce.version>3.5.0.Final</lettuce.version>
+		<lettuce.version>5.0.0.Beta1</lettuce.version>
 		<log4j.version>1.2.17</log4j.version>
 		<myfaces.version>2.2.11</myfaces.version>
 		<nimbus-jose-jwt.version>4.34.1</nimbus-jose-jwt.version>


### PR DESCRIPTION
This PR is to set the _Lettuce_ version to `5.0.0.Beta1` from the [current version of `3.5.0.Final`](https://github.com/spring-io/platform/blob/master/platform-bom/pom.xml#L128).

@rwinch informed me that the _Spring Session_ `2.0.x` build (based on _Spring Boot_ **2.0** and _Spring IO Platform_ **Cairo**) currently needs to override the _Lettuce_ version supplied by the _Spring IO Plaform_ for the _Spring Session Data Redis_ support and samples, otherwise a `ClassNotFoundException` occurs at runtime.

This is necessary as _Spring Data_ **2.0.x** moves to _Reactive_ support for **Redis**, **Mongo**, **Cassandra** along with other data store already having Reactive-based drivers.

If you peer into the _Spring Data Redis_ **2.0.x** branch, you will see that the expected _Lettuce_ driver is [set to 5.0.0.Beta1](https://github.com/spring-projects/spring-data-redis/blob/2.0.x/pom.xml#L24).

Lettuce 5.0.0.Beta1 is necessary to support the Reactive extensions in _Spring Data_ (Redis) **2.0** (**Kay**).

Thanks,
@jxblum