### PR TITLE
Use https://spring.io as project URL

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -16,10 +16,10 @@
 	<packaging>pom</packaging>
 	<name>Spring IO Platform bill of materials</name>
 	<description>Spring IO Platform bill of materials</description>
-	<url>http://platform.spring.io/platform/</url>
+	<url>https://platform.spring.io/platform/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 	<licenses>
 		<license>
@@ -37,7 +37,7 @@
 			<name>Andy Wilkinson</name>
 			<email>awilkinson at pivotal.io</email>
 			<organization>Pivotal Software, Inc.</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://spring.io</organizationUrl>
 			<roles>
 				<role>Project lead</role>
 			</roles>

--- a/platform-tests/pom.xml
+++ b/platform-tests/pom.xml
@@ -12,10 +12,10 @@
 	<artifactId>platform-tests</artifactId>
 	<name>Spring IO Platform integration tests</name>
 	<description>Performs sanity testing of the Platform</description>
-	<url>http://platform.spring.io/platform/</url>
+	<url>https://platform.spring.io/platform/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 
 	<properties>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>platform</artifactId>
 	<name>Spring IO Platform documentation</name>
 	<description>Spring IO Platform documentation</description>
-	<url>http://platform.spring.io/platform/</url>
+	<url>https://platform.spring.io/platform/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
 		<url>https://spring.io</url>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -14,7 +14,7 @@
 	<url>http://platform.spring.io/platform/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 	<licenses>
 		<license>
@@ -32,7 +32,7 @@
 			<name>Andy Wilkinson</name>
 			<email>awilkinson at pivotal.io</email>
 			<organization>Pivotal Software, Inc.</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://spring.io</organizationUrl>
 			<roles>
 				<role>Project lead</role>
 			</roles>

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,10 @@
 	<packaging>pom</packaging>
 	<name>Spring IO Platform build</name>
 	<description>Spring IO Platform build</description>
-	<url>http://platform.spring.io/platform/</url>
+	<url>https://platform.spring.io/platform/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://spring.io</url>
 	</organization>
 	<licenses>
 		<license>
@@ -30,7 +30,7 @@
 			<name>Andy Wilkinson</name>
 			<email>awilkinson at pivotal.io</email>
 			<organization>Pivotal Software, Inc.</organization>
-			<organizationUrl>http://www.spring.io</organizationUrl>
+			<organizationUrl>https://spring.io</organizationUrl>
 			<roles>
 				<role>Project lead</role>
 			</roles>


### PR DESCRIPTION
Replace `http://www.spring.io` by `https://spring.io` to avoid HTTP redirection.