### PR TITLE
Dependency management for ROME is incomplete

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -365,6 +365,11 @@
 				<version>${rometools.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>com.rometools</groupId>
+				<artifactId>rome-modules</artifactId>
+				<version>${rometools.version}</version>
+			</dependency>			
+			<dependency>
 				<groupId>com.splunk</groupId>
 				<artifactId>splunk</artifactId>
 				<version>${splunk.version}</version>

--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -361,14 +361,29 @@
 			</dependency>
 			<dependency>
 				<groupId>com.rometools</groupId>
-				<artifactId>rome-fetcher</artifactId>
+				<artifactId>rome-propono</artifactId>
+				<version>${rometools.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.rometools</groupId>
+				<artifactId>rome-opml</artifactId>
 				<version>${rometools.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.rometools</groupId>
 				<artifactId>rome-modules</artifactId>
 				<version>${rometools.version}</version>
-			</dependency>			
+			</dependency>
+			<dependency>
+				<groupId>com.rometools</groupId>
+				<artifactId>rome-certiorem</artifactId>
+				<version>${rometools.version}</version>
+			</dependency>	
+			<dependency>
+				<groupId>com.rometools</groupId>
+				<artifactId>rome-fetcher</artifactId>
+				<version>${rometools.version}</version>
+			</dependency>		
 			<dependency>
 				<groupId>com.splunk</groupId>
 				<artifactId>splunk</artifactId>


### PR DESCRIPTION
Add [all ROME modules](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.rometools%22):
- rome-propono ([deprecated](/rometools/rome#rome))
- rome-opml
- rome-modules
- rome-certiorem ([deprecated](/rometools/rome#rome))
- rome-fetcher (already listed) ([deprecated](/rometools/rome#rome))


