### PR TITLE
Remove spring-cql

### DIFF
--- a/platform-definition.yaml
+++ b/platform-definition.yaml
@@ -126,7 +126,6 @@ platform_definition:
       groupId: org.springframework.data
       version: 2.0.0.M3
       modules:
-        - spring-cql
         - spring-data-cassandra
     - name: Spring Data Commons
       groupId: org.springframework.data


### PR DESCRIPTION
Spring CQL was merged with Spring Data Kay M4 into Spring Data Cassandra and is no longer available as standalone library.

---

Requires: Spring Data Kay M4