### PR TITLE
Remove spring-data-mongodb-log4j

### DIFF
--- a/platform-definition.yaml
+++ b/platform-definition.yaml
@@ -173,7 +173,6 @@ platform_definition:
       version: 2.0.0.BUILD-SNAPSHOT
       modules:
         - spring-data-mongodb
-        - spring-data-mongodb-log4j
         - spring-data-mongodb-cross-store
     - name: Spring Data Neo4j
       id: spring.data.neo4j


### PR DESCRIPTION
`spring-data-mongodb-log4j` is no longer provided by Spring Data MongoDB.

See also [DATAMONGO-1715](https://jira.spring.io/browse/DATAMONGO-1715).