### PR TITLE
Add dependency management for Commons Text

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -72,6 +72,7 @@
 		<commons-lang.version>2.6</commons-lang.version>
 		<commons-logging.version>1.2</commons-logging.version>
 		<commons-net.version>3.6</commons-net.version>
+		<commons-text.version>1.1</commons-text.version>
 		<curator.version>2.12.0</curator.version>
 		<eclipselink.version>2.7.0</eclipselink.version>
 		<eclipselink-javax-persistence.version>2.2.0</eclipselink-javax-persistence.version>
@@ -600,6 +601,11 @@
 				<groupId>net.sf.jopt-simple</groupId>
 				<artifactId>jopt-simple</artifactId>
 				<version>${jopt-simple.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-text</artifactId>
+				<version>${commons-text.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.curator</groupId>


### PR DESCRIPTION
Platform provides dependency management for Commons Lang 3.x, however with release 3.6 string
focused functionality has been deprecated and moved to
Commons Text (see the [Commons Lang 3.6 release notes](https://www.apache.org/dist/commons/lang/RELEASE-NOTES.txt)).

It would be nice if Platform would provide the dependency management for newly introduced Commons Text.