### PR TITLE
Remove javax.money:money-api

### DIFF
--- a/platform-bom/pom.xml
+++ b/platform-bom/pom.xml
@@ -107,7 +107,6 @@
 		<javax-jax-ws.version>2.3.0</javax-jax-ws.version>
 		<javax-jsp.version>2.3.2-b02</javax-jsp.version>
 		<javax-jstl.version>1.2.1</javax-jstl.version>
-		<javax-money.version>1.0.1</javax-money.version>
 		<javax-resource.version>1.7</javax-resource.version>
 		<javax-websocket.version>1.1</javax-websocket.version>
 		<jbatch-tck.version>1.0</jbatch-tck.version>
@@ -571,11 +570,6 @@
 				<groupId>javax.interceptor</groupId>
 				<artifactId>javax.interceptor-api</artifactId>
 				<version>${javax-interceptor.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.money</groupId>
-				<artifactId>money-api</artifactId>
-				<version>${javax-money.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.resource</groupId>

--- a/platform-definition.yaml
+++ b/platform-definition.yaml
@@ -285,7 +285,7 @@ platform_definition:
         - spring-integration-splunk
     - name: Spring Kafka
       groupId: org.springframework.kafka
-      version: 2.1.0.RC1
+      version: 2.1.0.RELEASE
       modules:
         - spring-kafka
         - spring-kafka-test


### PR DESCRIPTION
Dependency management for `javax.money:money-api` has been added in Spring Boot via https://github.com/spring-projects/spring-boot/commit/6eabe8235c41b78f30e253e381aa473fb933dc8a, so this PR removes it.

This PR also upgrades to Spring Kafka 2.1.0.RELEASE to pass tests.