### PR TITLE
README links to http://spring.io/platform with does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Contributors to this project agree to uphold its [code of conduct][].
 ## License
 Spring IO Platform is released under version 2.0 of the [Apache License][].
 
-[Spring IO Platform website]: http://spring.io/platform
+[Spring IO Platform website]: https://platform.spring.io/platform/
 [Platform Maven docs]: http://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-using-spring-io-platform-maven
 [dependency management plugin]: https://plugins.gradle.org/plugin/io.spring.dependency-management
 [Platform Gradle docs]: http://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-using-spring-io-platform-gradle


### PR DESCRIPTION
https://github.com/spring-io/platform links to http://spring.io/platform but that URL returns 404 Not Found.

This broken link is also at the top of https://github.com/spring-io/platform next to the repository description, but I don't think I can send a pull request for that.