### PR TITLE
URL Cleanup

### DIFF
--- a/platform/src/main/docbook/xsl/xslthl-config.xml
+++ b/platform/src/main/docbook/xsl/xslthl-config.xml
@@ -19,5 +19,5 @@
 	<highlighter id="properties" file="./xslthl/properties-hl.xml" />
 	<highlighter id="json" file="./xslthl/json-hl.xml" />
 	<highlighter id="yaml" file="./xslthl/yaml-hl.xml" />
-	<namespace prefix="xslthl" uri="http://xslthl.sf.net" />
+	<namespace prefix="xslthl" uri="http://xslthl.sourceforge.net/" />
 </xslthl-config>

--- a/platform/src/main/docbook/xsl/xslthl/bourne-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/bourne-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for SH
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2010 Mathieu Malaterre
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/c-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/c-hl.xml
@@ -3,7 +3,7 @@
 Syntax highlighting definition for C
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/cpp-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/cpp-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for C++
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/csharp-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/csharp-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for C#
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/css-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/css-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for CSS files
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2011-2012 Martin Hujer, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied
@@ -26,7 +26,7 @@ freely, subject to the following restrictions:
 Martin Hujer <mhujer at users.sourceforge.net>
 Michiel Hendriks <elmuerte at users.sourceforge.net>
 
-Reference: http://www.w3.org/TR/CSS21/propidx.html
+Reference: https://www.w3.org/TR/CSS21/propidx.html
 
 -->
 <highlighters>

--- a/platform/src/main/docbook/xsl/xslthl/html-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/html-hl.xml
@@ -7,7 +7,7 @@
   myxml-hl.xml - konfigurace zvyraznovace XML, ktera zvlast zvyrazni
                  HTML elementy a XSL elementy
 
-  This file has been customized for the Asciidoctor project (http://asciidoctor.org).
+  This file has been customized for the Asciidoctor project (https://asciidoctor.org).
 -->
 <highlighters>
   <highlighter type="xml">

--- a/platform/src/main/docbook/xsl/xslthl/ini-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/ini-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for ini files
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/java-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/java-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Java
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/javascript-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/javascript-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for JavaScript
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/perl-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/perl-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Perl
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/php-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/php-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for PHP
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/properties-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/properties-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Java
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/python-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/python-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Python
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/ruby-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/ruby-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for Ruby
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2005-2008 Michal Molhanec, Jirka Kosek, Michiel Hendriks
 
 This software is provided 'as-is', without any express or implied

--- a/platform/src/main/docbook/xsl/xslthl/sql2003-hl.xml
+++ b/platform/src/main/docbook/xsl/xslthl/sql2003-hl.xml
@@ -4,7 +4,7 @@
 Syntax highlighting definition for SQL:1999
 
 xslthl - XSLT Syntax Highlighting
-http://sourceforge.net/projects/xslthl/
+https://sourceforge.net/projects/xslthl/
 Copyright (C) 2012 Michiel Hendriks, Martin Hujer, k42b3
 
 This software is provided 'as-is', without any express or implied


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://xslthl.sf.net (301) with 1 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* http://sourceforge.net/projects/xslthl/ with 14 occurrences migrated to:  
  https://sourceforge.net/projects/xslthl/ ([https](https://sourceforge.net/projects/xslthl/) result 200).
* http://www.w3.org/TR/CSS21/propidx.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/CSS21/propidx.html ([https](https://www.w3.org/TR/CSS21/propidx.html) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences