### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -42,5 +42,5 @@ with regard to the reporter of an incident.
 This Code of Conduct is adapted from the [Contributor Covenant][1], version 1.3.0, available
 at [contributor-covenant.org/version/1/3/0/][2].
 
-[1]: http://contributor-covenant.org
-[2]: http://contributor-covenant.org/version/1/3/0/
+[1]: https://contributor-covenant.org
+[2]: https://contributor-covenant.org/version/1/3/0/

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Contributors to this project agree to uphold its [code of conduct][].
 Spring IO Platform is released under version 2.0 of the [Apache License][].
 
 [Spring IO Platform website]: https://platform.spring.io/platform/
-[Platform Maven docs]: http://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-using-spring-io-platform-maven
+[Platform Maven docs]: https://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-using-spring-io-platform-maven
 [dependency management plugin]: https://plugins.gradle.org/plugin/io.spring.dependency-management
-[Platform Gradle docs]: http://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-using-spring-io-platform-gradle
+[Platform Gradle docs]: https://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started-using-spring-io-platform-gradle
 [code of conduct]: CODE_OF_CONDUCT.md
 [Pull requests]: https://help.github.com/articles/using-pull-requests/
 [contributor guidelines]: CONTRIBUTING.md

--- a/platform-definition.yaml
+++ b/platform-definition.yaml
@@ -909,10 +909,10 @@ platform_definition:
     'org.yaml:snakeyaml': '1.20'
   repositories:
       - id: central
-        url: http://repo1.maven.org/maven2
+        url: https://repo1.maven.org/maven2
       - id: spring-snapshots
-        url: http://repo.spring.io/libs-snapshot
+        url: https://repo.spring.io/libs-snapshot
       - id: jasper-reports
-        url: http://jasperreports.sourceforge.net/maven2
+        url: http://jasperreports.sourceforge.net/maven2/
       - id: neo4j-snapshots
-        url: http://m2.neo4j.org/content/repositories/snapshots
+        url: https://m2.neo4j.org/content/repositories/snapshots

--- a/platform-tests/src/test/resources/gradle-header.template
+++ b/platform-tests/src/test/resources/gradle-header.template
@@ -18,7 +18,7 @@ dependencyManagement {
 repositories {
 	mavenCentral()
 	flatDir { dirs '../dependency' }
-	maven { url 'http://repo.spring.io/libs-snapshot' }
+	maven { url 'https://repo.spring.io/libs-snapshot' }
 }
 
 configurations {

--- a/platform-tests/src/test/resources/pom-footer.template
+++ b/platform-tests/src/test/resources/pom-footer.template
@@ -3,7 +3,7 @@
 		<repository>
 			<id>platform-maven-test-spring-libs-snapshot</id>
 			<name>Spring Snapshots repository</name>
-			<url>http://repo.spring.io/libs-snapshot</url>
+			<url>https://repo.spring.io/libs-snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>

--- a/platform-tests/src/test/resources/pom-header.template
+++ b/platform-tests/src/test/resources/pom-header.template
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/platform/src/main/asciidoc/documentation-overview.adoc
+++ b/platform/src/main/asciidoc/documentation-overview.adoc
@@ -26,8 +26,8 @@ Copyright Notice, whether distributed in print or electronically.
 If you're having trouble with Spring IO Platform, we'd like to help:
 
 * Learn the Spring basics -- Spring IO Platform brings together many Spring projects, check the
-  http://spring.io[spring.io] website for a wealth of reference documentation. If you are just
-  starting out with Spring, try one of the http://spring.io/guides[guides].
+  https://spring.io[spring.io] website for a wealth of reference documentation. If you are just
+  starting out with Spring, try one of the https://spring.io/guides[guides].
 * Report bugs with the Spring IO Platform at {github-issues}.
 
 NOTE: All of Spring IO Platform is open source, including this documentation. If you find problems

--- a/platform/src/main/asciidoc/getting-started.adoc
+++ b/platform/src/main/asciidoc/getting-started.adoc
@@ -29,7 +29,7 @@ can import the Platform's bom into your application's pom:
 	<?xml version="1.0" encoding="UTF-8"?>
 	<project xmlns="http://maven.apache.org/POM/4.0.0"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 		<modelVersion>4.0.0</modelVersion>
 
@@ -59,14 +59,14 @@ endif::[]
 ifeval::["{platform-repo}" == "snapshot"]
 			<repository>
 				<id>spring-snapshots</id>
-				<url>http://repo.spring.io/libs-snapshot</url>
+				<url>https://repo.spring.io/libs-snapshot</url>
 				<snapshots><enabled>true</enabled></snapshots>
 			</repository>
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
 			<repository>
 				<id>spring-milestones</id>
-				<url>http://repo.spring.io/libs-milestone</url>
+				<url>https://repo.spring.io/libs-milestone</url>
 			</repository>
 endif::[]
 ifeval::["{platform-repo}" != "release"]
@@ -78,14 +78,14 @@ endif::[]
 ifeval::["{platform-repo}" == "snapshot"]
 			<pluginRepository>
 				<id>spring-snapshots</id>
-				<url>http://repo.spring.io/libs-snapshot</url>
+				<url>https://repo.spring.io/libs-snapshot</url>
 				<snapshots><enabled>true</enabled></snapshots>
 			</pluginRepository>
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
 			<pluginRepository>
 				<id>spring-milestones</id>
-				<url>http://repo.spring.io/libs-milestone</url>
+				<url>https://repo.spring.io/libs-milestone</url>
 			</pluginRepository>
 endif::[]
 ifeval::["{platform-repo}" != "release"]
@@ -102,7 +102,7 @@ parent:
 	<?xml version="1.0" encoding="UTF-8"?>
 	<project xmlns="http://maven.apache.org/POM/4.0.0"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 		<modelVersion>4.0.0</modelVersion>
 
@@ -127,14 +127,14 @@ endif::[]
 ifeval::["{platform-repo}" == "snapshot"]
 			<repository>
 				<id>spring-snapshots</id>
-				<url>http://repo.spring.io/libs-snapshot</url>
+				<url>https://repo.spring.io/libs-snapshot</url>
 				<snapshots><enabled>true</enabled></snapshots>
 			</repository>
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
 			<repository>
 				<id>spring-milestones</id>
-				<url>http://repo.spring.io/libs-milestone</url>
+				<url>https://repo.spring.io/libs-milestone</url>
 			</repository>
 endif::[]
 ifeval::["{platform-repo}" != "release"]
@@ -146,14 +146,14 @@ endif::[]
 ifeval::["{platform-repo}" == "snapshot"]
 			<pluginRepository>
 				<id>spring-snapshots</id>
-				<url>http://repo.spring.io/libs-snapshot</url>
+				<url>https://repo.spring.io/libs-snapshot</url>
 				<snapshots><enabled>true</enabled></snapshots>
 			</pluginRepository>
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
 			<pluginRepository>
 				<id>spring-milestones</id>
-				<url>http://repo.spring.io/libs-milestone</url>
+				<url>https://repo.spring.io/libs-milestone</url>
 			</pluginRepository>
 endif::[]
 ifeval::["{platform-repo}" != "release"]
@@ -233,10 +233,10 @@ To use the plugin, you configure your build to apply the plugin and then in the
 	repositories {
 		mavenCentral()
 ifeval::["{platform-repo}" == "snapshot"]
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
-		maven { url 'http://repo.spring.io/libs-milestone' }
+		maven { url 'https://repo.spring.io/libs-milestone' }
 endif::[]
 	}
 

--- a/platform/src/main/asciidoc/index.adoc
+++ b/platform/src/main/asciidoc/index.adoc
@@ -11,17 +11,17 @@ Andy Wilkinson;
 :dependency-management-plugin: https://plugins.gradle.org/plugin/io.spring.dependency-management
 :dependency-management-plugin-version: 1.0.0.RELEASE
 :platform-docs-version: current
-:platform-docs: http://docs.spring.io/platform/docs/{platform-docs-version}/reference
-:platform-docs-current: http://docs.spring.io/platform/docs/current/reference
-:platform-docs-20x: http://docs.spring.io/platform/docs/2.0.x/reference
+:platform-docs: https://docs.spring.io/platform/docs/{platform-docs-version}/reference
+:platform-docs-current: https://docs.spring.io/platform/docs/current/reference
+:platform-docs-20x: https://docs.spring.io/platform/docs/2.0.x/reference
 :github-repo: spring-io/platform
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :github-issues: https://github.com/{github-repo}/issues
-:github-master-code: http://github.com/{github-repo}/tree/master
-:maven-dependency-management: http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
-:spring-boot: http://projects.spring.io/spring-boot
-:spring-boot-docs: http://docs.spring.io/spring-boot/docs/{spring-boot-version}/reference/htmlsingle
+:github-master-code: https://github.com/{github-repo}/tree/master
+:maven-dependency-management: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
+:spring-boot: https://projects.spring.io/spring-boot
+:spring-boot-docs: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/reference/htmlsingle
 :spring-boot-docs-maven: {spring-boot-docs}/#using-boot-maven
 :spring-boot-docs-maven-plugin: {spring-boot-docs}/#build-tool-plugins-maven-plugin
 

--- a/platform/src/main/docbook/xsl/common.xsl
+++ b/platform/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/platform/src/main/docbook/xsl/epub.xsl
+++ b/platform/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/platform/src/main/docbook/xsl/html.xsl
+++ b/platform/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/platform/src/main/docbook/xsl/pdf.xsl
+++ b/platform/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://central.maven.org/maven2/ (200) with 1 occurrences could not be migrated:  
   ([https](https://central.maven.org/maven2/) result SSLHandshakeException).
* [ ] http://jasperreports.sourceforge.net/maven2 (301) with 1 occurrences could not be migrated:  
   ([https](https://jasperreports.sourceforge.net/maven2) result AnnotatedConnectException).
* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://github.com/ with 2 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html with 1 occurrences migrated to:  
  https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html ([https](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://spring.io/guides with 1 occurrences migrated to:  
  https://spring.io/guides ([https](https://spring.io/guides) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/platform/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/platform/docs/ ([https](https://docs.spring.io/platform/docs/) result 301).
* [ ] http://docs.spring.io/platform/docs/2.0.x/reference with 1 occurrences migrated to:  
  https://docs.spring.io/platform/docs/2.0.x/reference ([https](https://docs.spring.io/platform/docs/2.0.x/reference) result 301).
* [ ] http://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/ ([https](https://docs.spring.io/platform/docs/current-SNAPSHOT/reference/htmlsingle/) result 301).
* [ ] http://docs.spring.io/platform/docs/current/reference with 1 occurrences migrated to:  
  https://docs.spring.io/platform/docs/current/reference ([https](https://docs.spring.io/platform/docs/current/reference) result 301).
* [ ] http://m2.neo4j.org/content/repositories/snapshots with 1 occurrences migrated to:  
  https://m2.neo4j.org/content/repositories/snapshots ([https](https://m2.neo4j.org/content/repositories/snapshots) result 301).
* [ ] http://projects.spring.io/spring-boot with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).
* [ ] http://raw.github.com/ with 1 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://repo.spring.io/libs-milestone with 5 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 8 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* [ ] http://repo1.maven.org/maven2 with 1 occurrences migrated to:  
  https://repo1.maven.org/maven2 ([https](https://repo1.maven.org/maven2) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences