### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Spring IO Platform is released under version 2.0 of the [Apache License][].
 [code of conduct]: CODE_OF_CONDUCT.md
 [Pull requests]: https://help.github.com/articles/using-pull-requests/
 [contributor guidelines]: CONTRIBUTING.md
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/patches/reactor/001.patch
+++ b/patches/reactor/001.patch
@@ -23,7 +23,7 @@ index 574402e7..00000000
 - * you may not use this file except in compliance with the License.
 - * You may obtain a copy of the License at
 - *
-- *       http://www.apache.org/licenses/LICENSE-2.0
+- *       https://www.apache.org/licenses/LICENSE-2.0
 - *
 - * Unless required by applicable law or agreed to in writing, software
 - * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/AbstractDependenciesTests.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/AbstractDependenciesTests.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/AbstractProjectAnalysisTests.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/AbstractProjectAnalysisTests.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/ArtifactCoordinatesMatcher.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/ArtifactCoordinatesMatcher.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/BomDependenciesTests.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/BomDependenciesTests.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/DependencyMappings.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/DependencyMappings.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/GradleDependenciesTests.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/GradleDependenciesTests.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/MavenDependenciesTests.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/MavenDependenciesTests.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/UnusedDependenciesTests.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/UnusedDependenciesTests.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/model/Dependency.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/model/Dependency.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/model/DependencyScope.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/model/DependencyScope.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/model/Module.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/model/Module.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/model/Project.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/model/Project.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/resolution/DependenciesResolver.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/resolution/DependenciesResolver.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/resolution/aether/AetherDependenciesResolver.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/resolution/aether/AetherDependenciesResolver.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/resolution/aether/AetherHelper.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/resolution/aether/AetherHelper.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform-tests/src/test/groovy/io/spring/platform/resolution/aether/RepositoryDescriptor.groovy
+++ b/platform-tests/src/test/groovy/io/spring/platform/resolution/aether/RepositoryDescriptor.groovy
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/platform/src/main/docbook/xsl/common.xsl
+++ b/platform/src/main/docbook/xsl/common.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/platform/src/main/docbook/xsl/epub.xsl
+++ b/platform/src/main/docbook/xsl/epub.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/platform/src/main/docbook/xsl/html-multipage.xsl
+++ b/platform/src/main/docbook/xsl/html-multipage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/platform/src/main/docbook/xsl/html-singlepage.xsl
+++ b/platform/src/main/docbook/xsl/html-singlepage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/platform/src/main/docbook/xsl/html.xsl
+++ b/platform/src/main/docbook/xsl/html.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/platform/src/main/docbook/xsl/pdf.xsl
+++ b/platform/src/main/docbook/xsl/pdf.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 24 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).