### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -42,5 +42,5 @@ with regard to the reporter of an incident.
 This Code of Conduct is adapted from the [Contributor Covenant][1], version 1.3.0, available
 at [contributor-covenant.org/version/1/3/0/][2].
 
-[1]: http://contributor-covenant.org
-[2]: http://contributor-covenant.org/version/1/3/0/
+[1]: https://contributor-covenant.org
+[2]: https://contributor-covenant.org/version/1/3/0/

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Contributors to this project agree to uphold its [code of conduct][].
 ## License
 Spring IO Platform is released under version 2.0 of the [Apache License][].
 
-[Spring IO Platform website]: http://spring.io/platform
-[Platform Maven docs]: http://docs.spring.io/platform/docs/2.0.x/reference/htmlsingle/#getting-started-using-spring-io-platform-maven
+[Spring IO Platform website]: https://spring.io/platform
+[Platform Maven docs]: https://docs.spring.io/platform/docs/2.0.x/reference/htmlsingle/#getting-started-using-spring-io-platform-maven
 [dependency management plugin]: https://plugins.gradle.org/plugin/io.spring.dependency-management
-[Platform Gradle docs]: http://docs.spring.io/platform/docs/2.0.x/reference/htmlsingle/#getting-started-using-spring-io-platform-gradle
+[Platform Gradle docs]: https://docs.spring.io/platform/docs/2.0.x/reference/htmlsingle/#getting-started-using-spring-io-platform-gradle
 [code of conduct]: CODE_OF_CONDUCT.md
 [Pull requests]: https://help.github.com/articles/using-pull-requests/
 [contributor guidelines]: CONTRIBUTING.md

--- a/patches/spring-web-services/002.patch
+++ b/patches/spring-web-services/002.patch
@@ -49,7 +49,7 @@ index c0c8d1e..6baeaa7 100644
  
 -		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Body>" +
 +		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
- 				"<type xmlns='http://springframework.org'><string>Foo</string></type>" +
+ 				"<type xmlns='https://springframework.org'><string>Foo</string></type>" +
  				"</soapenv:Body></soapenv:Envelope>", messageResult);
  
 diff --git a/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/XmlRootElementPayloadMethodProcessorTest.java b/spring-ws-core/src/test/java/org/springframework/ws/server/endpoint/adapter/method/jaxb/XmlRootElementPayloadMethodProcessorTest.java
@@ -83,7 +83,7 @@ index 09aa7a6..dd3766a 100644
  		
 -		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Body>" +
 +		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
- 				"<root xmlns='http://springframework.org'><string>Foo</string></root>" +
+ 				"<root xmlns='https://springframework.org'><string>Foo</string></root>" +
  				"</soapenv:Body></soapenv:Envelope>", messageResult);
  
 @@ -230,7 +233,7 @@ public class XmlRootElementPayloadMethodProcessorTest {
@@ -92,7 +92,7 @@ index 09aa7a6..dd3766a 100644
  
 -		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Body>" +
 +		assertXMLEqual("<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'><soapenv:Header/><soapenv:Body>" +
- 				"<root xmlns='http://springframework.org'><string>Foo</string></root>" +
+ 				"<root xmlns='https://springframework.org'><string>Foo</string></root>" +
  				"</soapenv:Body></soapenv:Envelope>", messageResult);
  
 diff --git a/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java b/spring-ws-core/src/test/java/org/springframework/ws/soap/AbstractSoapMessageTestCase.java
@@ -343,8 +343,8 @@ index 3f405f1..4375fcf 100644
  		soapMessage.writeTo(tos);
  		String result = bos.toString("UTF-8");
  		assertXMLEqual(
--				"<Envelope xmlns='http://schemas.xmlsoap.org/soap/envelope/'><Body><payload xmlns='http://www.springframework.org' /></Body></Envelope>",
-+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+-				"<Envelope xmlns='http://schemas.xmlsoap.org/soap/envelope/'><Body><payload xmlns='https://www.springframework.org' /></Body></Envelope>",
++				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
  				result);
  		String contentType = tos.getHeaders().get("Content-Type");
  		assertTrue("Invalid Content-Type set", contentType.indexOf(SoapVersion.SOAP_11.getContentType()) != -1);
@@ -360,13 +360,13 @@ index 3f405f1..4375fcf 100644
 +
  		Element body = expected.createElementNS("http://schemas.xmlsoap.org/soap/envelope/", "Body");
  		envelope.appendChild(body);
- 		Element payload = expected.createElementNS("http://www.springframework.org", "payload");
+ 		Element payload = expected.createElementNS("https://www.springframework.org", "payload");
 @@ -123,7 +132,7 @@ public abstract class AbstractSoap11MessageTestCase extends AbstractSoapMessageT
  
  		String result = bos.toString("UTF-8");
  		assertXMLEqual(
--				"<Envelope xmlns='http://schemas.xmlsoap.org/soap/envelope/'><Body><payload xmlns='http://www.springframework.org' /></Body></Envelope>",
-+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+-				"<Envelope xmlns='http://schemas.xmlsoap.org/soap/envelope/'><Body><payload xmlns='https://www.springframework.org' /></Body></Envelope>",
++				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
  				result);
  	}
  
@@ -374,8 +374,8 @@ index 3f405f1..4375fcf 100644
  
  		String result = bos.toString("UTF-8");
  		assertXMLEqual(
--				"<Envelope xmlns='http://schemas.xmlsoap.org/soap/envelope/'><Body><payload xmlns='http://www.springframework.org' /></Body></Envelope>",
-+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+-				"<Envelope xmlns='http://schemas.xmlsoap.org/soap/envelope/'><Body><payload xmlns='https://www.springframework.org' /></Body></Envelope>",
++				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://schemas.xmlsoap.org/soap/envelope/'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
  				result);
  	}
  
@@ -415,8 +415,8 @@ index b5ae486..ed8e911 100644
  		soapMessage.writeTo(tos);
  		String result = bos.toString("UTF-8");
  		assertXMLEqual(
--				"<Envelope xmlns='http://www.w3.org/2003/05/soap-envelope'><Body><payload xmlns='http://www.springframework.org' /></Body></Envelope>",
-+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+-				"<Envelope xmlns='http://www.w3.org/2003/05/soap-envelope'><Body><payload xmlns='https://www.springframework.org' /></Body></Envelope>",
++				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
  				result);
  		String contentType = tos.getHeaders().get(TransportConstants.HEADER_CONTENT_TYPE);
  		assertTrue("Invalid Content-Type set",
@@ -432,13 +432,13 @@ index b5ae486..ed8e911 100644
 +
  		Element body = expected.createElementNS("http://www.w3.org/2003/05/soap-envelope", "Body");
  		envelope.appendChild(body);
- 		Element payload = expected.createElementNS("http://www.springframework.org", "payload");
+ 		Element payload = expected.createElementNS("https://www.springframework.org", "payload");
 @@ -128,7 +136,7 @@ public abstract class AbstractSoap12MessageTestCase extends AbstractSoapMessageT
  
  		String result = bos.toString("UTF-8");
  		assertXMLEqual(
--				"<Envelope xmlns='http://www.w3.org/2003/05/soap-envelope'><Body><payload xmlns='http://www.springframework.org' /></Body></Envelope>",				   
-+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+-				"<Envelope xmlns='http://www.w3.org/2003/05/soap-envelope'><Body><payload xmlns='https://www.springframework.org' /></Body></Envelope>",				   
++				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
  				result);
  	}
  
@@ -446,8 +446,8 @@ index b5ae486..ed8e911 100644
  
  		String result = bos.toString("UTF-8");
  		assertXMLEqual(
--				"<Envelope xmlns='http://www.w3.org/2003/05/soap-envelope'><Body><payload xmlns='http://www.springframework.org' /></Body></Envelope>",
-+				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='http://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
+-				"<Envelope xmlns='http://www.w3.org/2003/05/soap-envelope'><Body><payload xmlns='https://www.springframework.org' /></Body></Envelope>",
++				"<" + getNS() + ":Envelope xmlns:" + getNS() + "='http://www.w3.org/2003/05/soap-envelope'>" + getHeader() + "<" + getNS() + ":Body><payload xmlns='https://www.springframework.org' /></" + getNS() + ":Body></" + getNS() + ":Envelope>",
  				result);
  	}
  

--- a/platform-tests/src/test/resources/pom-header.template
+++ b/platform-tests/src/test/resources/pom-header.template
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/platform/src/main/asciidoc/documentation-overview.adoc
+++ b/platform/src/main/asciidoc/documentation-overview.adoc
@@ -26,8 +26,8 @@ Copyright Notice, whether distributed in print or electronically.
 If you're having trouble with Spring IO Platform, we'd like to help:
 
 * Learn the Spring basics -- Spring IO Platform brings together many Spring projects, check the
-  http://spring.io[spring.io] website for a wealth of reference documentation. If you are just
-  starting out with Spring, try one of the http://spring.io/guides[guides].
+  https://spring.io[spring.io] website for a wealth of reference documentation. If you are just
+  starting out with Spring, try one of the https://spring.io/guides[guides].
 * Report bugs with the Spring IO Platform at {github-issues}.
 
 NOTE: All of Spring IO Platform is open source, including this documentation. If you find problems

--- a/platform/src/main/asciidoc/getting-started.adoc
+++ b/platform/src/main/asciidoc/getting-started.adoc
@@ -29,7 +29,7 @@ can import the Platform's pom into your application's pom:
 	<?xml version="1.0" encoding="UTF-8"?>
 	<project xmlns="http://maven.apache.org/POM/4.0.0"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 		<modelVersion>4.0.0</modelVersion>
 
@@ -58,14 +58,14 @@ ifeval::["{platform-repo}" != "release"]
 ifeval::["{platform-repo}" == "snapshot"]
 			<repository>
 				<id>spring-snapshots</id>
-				<url>http://repo.spring.io/libs-snapshot</url>
+				<url>https://repo.spring.io/libs-snapshot</url>
 				<snapshots><enabled>true</enabled></snapshots>
 			</repository>
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
 			<repository>
 				<id>spring-milestones</id>
-				<url>http://repo.spring.io/libs-milestone</url>
+				<url>https://repo.spring.io/libs-milestone</url>
 			</repository>
 endif::[]
 		</repositories>
@@ -74,14 +74,14 @@ endif::[]
 ifeval::["{platform-repo}" == "snapshot"]
 			<pluginRepository>
 				<id>spring-snapshots</id>
-				<url>http://repo.spring.io/libs-snapshot</url>
+				<url>https://repo.spring.io/libs-snapshot</url>
 				<snapshots><enabled>true</enabled></snapshots>
 			</pluginRepository>
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
 			<pluginRepository>
 				<id>spring-milestones</id>
-				<url>http://repo.spring.io/libs-milestone</url>
+				<url>https://repo.spring.io/libs-milestone</url>
 			</pluginRepository>
 endif::[]
 		</pluginRepositories>
@@ -97,7 +97,7 @@ parent:
 	<?xml version="1.0" encoding="UTF-8"?>
 	<project xmlns="http://maven.apache.org/POM/4.0.0"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+			 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 		<modelVersion>4.0.0</modelVersion>
 
@@ -121,14 +121,14 @@ ifeval::["{platform-repo}" != "release"]
 ifeval::["{platform-repo}" == "snapshot"]
 			<repository>
 				<id>spring-snapshots</id>
-				<url>http://repo.spring.io/libs-snapshot</url>
+				<url>https://repo.spring.io/libs-snapshot</url>
 				<snapshots><enabled>true</enabled></snapshots>
 			</repository>
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
 			<repository>
 				<id>spring-milestones</id>
-				<url>http://repo.spring.io/libs-milestone</url>
+				<url>https://repo.spring.io/libs-milestone</url>
 			</repository>
 endif::[]
 		</repositories>
@@ -137,14 +137,14 @@ endif::[]
 ifeval::["{platform-repo}" == "snapshot"]
 			<pluginRepository>
 				<id>spring-snapshots</id>
-				<url>http://repo.spring.io/libs-snapshot</url>
+				<url>https://repo.spring.io/libs-snapshot</url>
 				<snapshots><enabled>true</enabled></snapshots>
 			</pluginRepository>
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
 			<pluginRepository>
 				<id>spring-milestones</id>
-				<url>http://repo.spring.io/libs-milestone</url>
+				<url>https://repo.spring.io/libs-milestone</url>
 			</pluginRepository>
 endif::[]
 		</pluginRepositories>
@@ -222,10 +222,10 @@ To use the plugin, you configure your build to apply the plugin and then in the
 	repositories {
 		mavenCentral()
 ifeval::["{platform-repo}" == "snapshot"]
-		maven { url 'http://repo.spring.io/libs-snapshot' }
+		maven { url 'https://repo.spring.io/libs-snapshot' }
 endif::[]
 ifeval::["{platform-repo}" == "milestone"]
-		maven { url 'http://repo.spring.io/libs-milestone' }
+		maven { url 'https://repo.spring.io/libs-milestone' }
 endif::[]
 	}
 

--- a/platform/src/main/asciidoc/index.adoc
+++ b/platform/src/main/asciidoc/index.adoc
@@ -11,16 +11,16 @@ Andy Wilkinson;
 :dependency-management-plugin: https://plugins.gradle.org/plugin/io.spring.dependency-management
 :dependency-management-plugin-version: 0.6.0.RELEASE
 :platform-docs-version: current
-:platform-docs: http://docs.spring.io/platform/docs/{platform-docs-version}/reference
-:platform-docs-current: http://docs.spring.io/platform/docs/current/reference
+:platform-docs: https://docs.spring.io/platform/docs/{platform-docs-version}/reference
+:platform-docs-current: https://docs.spring.io/platform/docs/current/reference
 :github-repo: spring-io/platform
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :github-issues: https://github.com/{github-repo}/issues
-:github-master-code: http://github.com/{github-repo}/tree/master
-:maven-dependency-management: http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
-:spring-boot: http://projects.spring.io/spring-boot
-:spring-boot-docs: http://docs.spring.io/spring-boot/docs/{spring-boot-version}/reference/htmlsingle
+:github-master-code: https://github.com/{github-repo}/tree/master
+:maven-dependency-management: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management
+:spring-boot: https://projects.spring.io/spring-boot
+:spring-boot-docs: https://docs.spring.io/spring-boot/docs/{spring-boot-version}/reference/htmlsingle
 :spring-boot-docs-maven: {spring-boot-docs}/#using-boot-maven
 :spring-boot-docs-maven-plugin: {spring-boot-docs}/#build-tool-plugins-maven-plugin
 

--- a/platform/src/main/docbook/xsl/common.xsl
+++ b/platform/src/main/docbook/xsl/common.xsl
@@ -20,7 +20,7 @@
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/platform/src/main/docbook/xsl/epub.xsl
+++ b/platform/src/main/docbook/xsl/epub.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl d"
 		version='1.0'>

--- a/platform/src/main/docbook/xsl/html.xsl
+++ b/platform/src/main/docbook/xsl/html.xsl
@@ -20,7 +20,7 @@ under the License.
 -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-		xmlns:xslthl="http://xslthl.sf.net"
+		xmlns:xslthl="http://xslthl.sourceforge.net/"
 		xmlns:d="http://docbook.org/ns/docbook"
 		exclude-result-prefixes="xslthl"
 		version='1.0'>

--- a/platform/src/main/docbook/xsl/pdf.xsl
+++ b/platform/src/main/docbook/xsl/pdf.xsl
@@ -22,7 +22,7 @@ under the License.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 				xmlns:d="http://docbook.org/ns/docbook"
 				xmlns:fo="http://www.w3.org/1999/XSL/Format"
-				xmlns:xslthl="http://xslthl.sf.net"
+				xmlns:xslthl="http://xslthl.sourceforge.net/"
 				xmlns:xlink='http://www.w3.org/1999/xlink'
 				xmlns:exsl="http://exslt.org/common"
 				exclude-result-prefixes="exsl xslthl d xlink"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://central.maven.org/maven2/ (200) with 1 occurrences could not be migrated:  
   ([https](https://central.maven.org/maven2/) result SSLHandshakeException).
* [ ] http://xslthl.sf.net (301) with 4 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).
* [ ] http://exslt.org/common (404) with 1 occurrences could not be migrated:  
   ([https](https://exslt.org/common) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/platform/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/platform/docs/ ([https](https://docs.spring.io/platform/docs/) result 200).
* [ ] http://docs.spring.io/platform/docs/2.0.x/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/platform/docs/2.0.x/reference/htmlsingle/ ([https](https://docs.spring.io/platform/docs/2.0.x/reference/htmlsingle/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://github.com/ with 2 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html with 1 occurrences migrated to:  
  https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html ([https](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://spring.io with 1 occurrences migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* [ ] http://spring.io/guides with 1 occurrences migrated to:  
  https://spring.io/guides ([https](https://spring.io/guides) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/platform/docs/current/reference with 1 occurrences migrated to:  
  https://docs.spring.io/platform/docs/current/reference ([https](https://docs.spring.io/platform/docs/current/reference) result 301).
* [ ] http://projects.spring.io/spring-boot with 1 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).
* [ ] http://raw.github.com/ with 1 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://springframework.org with 3 occurrences migrated to:  
  https://springframework.org ([https](https://springframework.org) result 301).
* [ ] http://www.springframework.org with 14 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://repo.spring.io/libs-milestone with 5 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* [ ] http://repo.spring.io/libs-snapshot with 5 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* [ ] http://spring.io/platform with 1 occurrences migrated to:  
  https://spring.io/platform ([https](https://spring.io/platform) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://docbook.sourceforge.net/xmlns/l10n/1.0 with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://schemas.xmlsoap.org/soap/envelope/ with 17 occurrences
* http://springframework.org/spring-ws with 1 occurrences
* http://www.w3.org/1999/XSL/Format with 2 occurrences
* http://www.w3.org/1999/XSL/Transform with 6 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 3 occurrences
* http://www.w3.org/2003/05/soap-envelope with 9 occurrences